### PR TITLE
perf(memoize): memoize large data maps for perf reasons

### DIFF
--- a/lib/memoizer.js
+++ b/lib/memoizer.js
@@ -1,0 +1,13 @@
+"use strict";
+
+function Memoizer() {
+  this.memoized = {};
+}
+Memoizer.prototype.set = function(name, value) {
+  this.memoized[name] = value;
+};
+Memoizer.prototype.get = function(name) {
+  return this.memoized[name];
+};
+
+module.exports = Memoizer;

--- a/sass/lib/alias.scss
+++ b/sass/lib/alias.scss
@@ -10,6 +10,8 @@
 
   $-restyle--registered-aliases: map-merge($-restyle--registered-aliases, $alias) !global;
 
+  $tmp: -restyle--memoize-js(aliases, $-restyle--registered-aliases);
+
   @return true;
 }
 

--- a/sass/lib/define.scss
+++ b/sass/lib/define.scss
@@ -10,11 +10,13 @@
 
   // add the name to the known types...
   $-restyle--registered-types: append($-restyle--registered-types, $name) !global;
+  $-restyle--is-registered-types-dirty: true !global; // mark it as dirty
 
   // add the definition to the map...
   $-restyle--registered-patterns: map-merge($-restyle--registered-patterns, (
     #{$name}: $definition
   )) !global;
+  $-restyle--is-registered-patterns-dirty: true !global; // mark it as dirty
 
   @if ($placeholder) {
     $-restyle--registered-pattern-placeholders: map-merge($-restyle--registered-pattern-placeholders, (

--- a/sass/lib/extend.scss
+++ b/sass/lib/extend.scss
@@ -21,6 +21,7 @@
   $-restyle--registered-patterns: map-merge($-restyle--registered-patterns, (
     #{$name}: $extended-definition
   )) !global;
+  $-restyle--is-registered-patterns-dirty: true !global; // mark it as dirty
 
   $tmp: -restyle--log($debug-message, "time:extend", (
     time: -restyle--timer-js($start-time)

--- a/sass/lib/grammar.scss
+++ b/sass/lib/grammar.scss
@@ -10,12 +10,15 @@
     description: $descriptor
   ));
 
+  // if the types are makred dirty, we need to update the memoized store
+  @if ($-restyle--is-registered-types-dirty) {
+    $tmp: -restyle--memoize-js(types, $-restyle--registered-types);
+    $-restyle--is-registered-types-dirty: false !global; // mark it as clean
+  }
+
   $result: -restyle--grammar-from-description-js(
     map-get($descriptor, description),
-    map-get($descriptor, type),
-    $-restyle--registered-types,
-    $-restyle--registered-aliases,
-    $-restyle--grammar-context-stack
+    map-get($descriptor, type)
   );
 
   $tmp: -restyle--log($debug-message, "time:grammar", (

--- a/sass/lib/main.scss
+++ b/sass/lib/main.scss
@@ -28,8 +28,10 @@
   @include -restyle--styles($styles) {
     $previous-grammar-context-stack: $-restyle--grammar-context-stack;
     $-restyle--grammar-context-stack: append($-restyle--grammar-context-stack, $grammars) !global;
+    $tmp: -restyle--memoize-js(grammar-context-stack, $-restyle--grammar-context-stack);
     @content;
     $-restyle--grammar-context-stack: $previous-grammar-context-stack !global;
+    $tmp: -restyle--memoize-js(grammar-context-stack, $-restyle--grammar-context-stack);
   }
 
 }

--- a/sass/lib/shared.scss
+++ b/sass/lib/shared.scss
@@ -9,5 +9,12 @@ $-restyle--registered-pattern-placeholders: () !default;
 $-restyle--registered-smart-placeholders: () !default;
 $-restyle--grammar-context-stack: () !default;
 $-restyle--log-msg-history: () !default;
+$-restyle--is-registered-types-dirty: true !default;
+$-restyle--is-registered-patterns-dirty: true !default;
+
+@at-root {
+  $tmp: -restyle--memoize-js(aliases, $-restyle--registered-aliases);
+  $tmp: -restyle--memoize-js(grammar-context-stack, $-restyle--grammar-context-stack);
+}
 
 @import "./util";

--- a/sass/lib/styles.scss
+++ b/sass/lib/styles.scss
@@ -13,12 +13,21 @@
 
   $start-time: -restyle--timer-js();
 
+  // if the patterns are makred dirty, we need to update the memoized store
+  @if ($-restyle--is-registered-patterns-dirty) {
+    $tmp: -restyle--memoize-js(patterns, $-restyle--registered-patterns, (
+      shallow: true // only do a shallow conversion
+    ));
+    $-restyle--is-registered-patterns-dirty: false !global; // mark it as clean
+  }
+  // if the types are makred dirty, we need to update the memoized store
+  @if ($-restyle--is-registered-types-dirty) {
+    $tmp: -restyle--memoize-js(types, $-restyle--registered-types);
+    $-restyle--is-registered-types-dirty: false !global; // mark it as clean
+  }
+
   $result: -restyle--styles-from-grammar-js(
     $grammars,
-    $-restyle--registered-types,
-    $-restyle--registered-patterns,
-    $-restyle--registered-aliases,
-    $-restyle--grammar-context-stack,
     $variables
   );
 


### PR DESCRIPTION
This uses a memoizer to reduce the number of times we pass large maps between Sass and JS land.

This is to help alleviate some of the performance overhead due to sass/node-sass/issues/1198.