### PR TITLE
Fix Sass "call" Deprecation Warnings

### DIFF
--- a/sass/lib/styles.scss
+++ b/sass/lib/styles.scss
@@ -181,7 +181,7 @@
             @each $function, $args in $value {
               @if (type-of($function) == string) {
                 $args: -restyle--cast-to-args($args);
-                @include -restyle--styles(call($function, $args...));
+                @include -restyle--styles(call(get-function($function), $args...));
               }
             }
           }

--- a/test/fixtures/noconflict.scss
+++ b/test/fixtures/noconflict.scss
@@ -9,7 +9,7 @@ $data: (
   @each $name in $names {
     // TODO - support variable-exists as well
     $existsFn: "#{$type}-exists";
-    $result: call($existsFn, $name);
+    $result: call(get-function($existsFn), $name);
     /* #{$type} `#{$name}` exists? #{$result} */
   }
 }


### PR DESCRIPTION
- previously call was being used with function strings, rather than function references
- change to use function references via get-function