### PR TITLE
Change eyeglass `needs` to star

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   ],
   "eyeglass": {
     "name": "restyle",
-    "needs": "^1.0.0"
+    "needs": "*"
   },
   "dependencies": {
     "crc": "^3.3.0",


### PR DESCRIPTION
Looking to update ember-cli-eyeglass to 7.x, which pulls in eyeglass v3.x, to speed up builds. This addon console logs a lot about being unhappy due to `"needs": "^1.0.0"`